### PR TITLE
Fix missing bot polling call

### DIFF
--- a/test_bot.py
+++ b/test_bot.py
@@ -1936,3 +1936,7 @@ export COC_API_TOKEN="yeni_token_buraya"
                         self.send_message(chat_id, f"🚫 **{name}** 3 uyarı aldığı için klandan atılmalı!")
                     else:
                         self.send_message(chat_id, f"⚠️ **{name}**, küfür yasak! Uyarı: {warnings}/3")
+
+
+if __name__ == '__main__':
+    bot.polling(none_stop=True)


### PR DESCRIPTION
## Summary
- ensure the Telegram bot starts polling for messages

## Testing
- `python -m py_compile test_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686f156b1a2c8327a6f010344b2340a8